### PR TITLE
feat: image url pattern env config support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,9 @@ ALLOW_EVENTS_NOT_OLDER_THAN_MINUTES = 10
 ENABLE_MQTT_PUBLISH = false
 # (Optional) you need to set comma-separated mqtt broker list to forward and publish nostr event only if ENABLE_MQTT_PUBLISH == true
 MQTT_BROKER_TO_PUBLISH = mqtt://localhost:5000, mqtts://localhost:5001
+
+# Additional image url regular expression pattern to be used for image classification requests. 
+# User can also add environment variable like this:
+# IMAGE_URL_PATTERN_0=hostname1.tld 
+# IMAGE_URL_PATTERN_1=/hostname2.tld/files/
+# IMAGE_URL_PATTERN_2=or_any_pattern


### PR DESCRIPTION
This PR can be used especially in cases of media servers don't have url with image extensions (.jpg, .png, .etc). 

Examples:
1. Bluesky bridge has "getBlob" pattern  for media url
2. Some media storage with url: https://domain.tld/files/uuid-pattern-or-sha256sum-without-extensions